### PR TITLE
Use credential or config in ~/.aws/ by default

### DIFF
--- a/db/dbsession.go
+++ b/db/dbsession.go
@@ -12,14 +12,28 @@ var DynamoDB *dynamodb.DynamoDB
 
 // GetDynamoSession returns a new dynamodb session
 func GetDynamoSession(accessKeyID, secretAccessKey, region string) *dynamodb.DynamoDB {
-	token := ""
-	creds := credentials.NewStaticCredentials(accessKeyID, secretAccessKey, token)
-	_, err := creds.Get()
-	if err != nil {
-		panic(err)
+	session_config := session.Options{}
+	if accessKeyID != "" || secretAccessKey != "" {
+		token := ""
+		creds := credentials.NewStaticCredentials(accessKeyID, secretAccessKey, token)
+		_, err := creds.Get()
+		if err != nil {
+			panic(err)
+		}
+		session_config.Config.Credentials = creds
 	}
 
-	DynamoDB = dynamodb.New(session.New(&aws.Config{Region: &region}))
+	if region != "" {
+		session_config.Config.Region = &region
+	} else {
+		session_config.SharedConfigState = session.SharedConfigEnable
+	}
+
+	session, err := session.NewSessionWithOptions(session_config)
+	if err != nil{
+		panic(err)
+	}
+	DynamoDB = dynamodb.New(session)
 	return DynamoDB
 }
 

--- a/db/dbsession.go
+++ b/db/dbsession.go
@@ -12,7 +12,7 @@ var DynamoDB *dynamodb.DynamoDB
 
 // GetDynamoSession returns a new dynamodb session
 func GetDynamoSession(accessKeyID, secretAccessKey, region string) *dynamodb.DynamoDB {
-	session_config := session.Options{}
+	sessionConfig := session.Options{}
 	if accessKeyID != "" || secretAccessKey != "" {
 		token := ""
 		creds := credentials.NewStaticCredentials(accessKeyID, secretAccessKey, token)
@@ -20,17 +20,17 @@ func GetDynamoSession(accessKeyID, secretAccessKey, region string) *dynamodb.Dyn
 		if err != nil {
 			panic(err)
 		}
-		session_config.Config.Credentials = creds
+		sessionConfig.Config.Credentials = creds
 	}
 
 	if region != "" {
-		session_config.Config.Region = &region
+		sessionConfig.Config.Region = &region
 	} else {
-		session_config.SharedConfigState = session.SharedConfigEnable
+		sessionConfig.SharedConfigState = session.SharedConfigEnable
 	}
 
-	session, err := session.NewSessionWithOptions(session_config)
-	if err != nil{
+	session, err := session.NewSessionWithOptions(sessionConfig)
+	if err != nil {
 		panic(err)
 	}
 	DynamoDB = dynamodb.New(session)

--- a/db/dbsession.go
+++ b/db/dbsession.go
@@ -11,14 +11,14 @@ import (
 var DynamoDB *dynamodb.DynamoDB
 
 // GetDynamoSession returns a new dynamodb session
-func GetDynamoSession(accessKeyID, secretAccessKey, region string) *dynamodb.DynamoDB {
+func GetDynamoSession(accessKeyID, secretAccessKey, region string) (*dynamodb.DynamoDB, error) {
 	sessionConfig := session.Options{}
 	if accessKeyID != "" || secretAccessKey != "" {
 		token := ""
 		creds := credentials.NewStaticCredentials(accessKeyID, secretAccessKey, token)
 		_, err := creds.Get()
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 		sessionConfig.Config.Credentials = creds
 	}
@@ -31,10 +31,10 @@ func GetDynamoSession(accessKeyID, secretAccessKey, region string) *dynamodb.Dyn
 
 	session, err := session.NewSessionWithOptions(sessionConfig)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	DynamoDB = dynamodb.New(session)
-	return DynamoDB
+	return DynamoDB, nil
 }
 
 // ListTable returns all table names from dynamoDB

--- a/main.go
+++ b/main.go
@@ -213,12 +213,8 @@ func main() {
 			},
 		},
 		Action: func(c *cli.Context) error {
-			if region == "" {
-				fmt.Println("Must provide aws config region")
-			} else if accessKeyID == "" {
-				fmt.Println("Must provide aws config access key id")
-			} else if secretAccessKey == "" {
-				fmt.Println("Must provide aws config secret access key")
+			if !((accessKeyID == "" && secretAccessKey == "") || (accessKeyID != "" && secretAccessKey != "")){
+				fmt.Println("Must provide access key id and secret access key at the same time")
 			} else {
 				db.GetDynamoSession(accessKeyID, secretAccessKey, region)
 				runPrompt(tablePrefix)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -213,13 +214,14 @@ func main() {
 			},
 		},
 		Action: func(c *cli.Context) error {
-			if !((accessKeyID == "" && secretAccessKey == "") || (accessKeyID != "" && secretAccessKey != "")){
-				fmt.Println("Must provide access key id and secret access key at the same time")
-			} else {
-				db.GetDynamoSession(accessKeyID, secretAccessKey, region)
+			if !((accessKeyID == "" && secretAccessKey == "") || (accessKeyID != "" && secretAccessKey != "")) {
+				return errors.New("Must provide access key id and secret access key at the same time")
+			} else if _, err := db.GetDynamoSession(accessKeyID, secretAccessKey, region); err == nil {
 				runPrompt(tablePrefix)
+				return nil
+			} else {
+				return err
 			}
-			return nil
 		},
 	}
 


### PR DESCRIPTION
1. Secret key and id must be provided at the same time, or the ~/.aws/credential will be load;
2. If region is not specified, the ~/.aws/config will be load